### PR TITLE
Ensure binaries are run by unknown UID

### DIFF
--- a/openshift/ci-operator/images/kn-event-sender/Dockerfile
+++ b/openshift/ci-operator/images/kn-event-sender/Dockerfile
@@ -1,3 +1,4 @@
 FROM base
 ADD kn-event-sender /usr/bin/kn-event-sender
+USER 65532
 ENTRYPOINT ["/usr/bin/kn-event-sender"]

--- a/openshift/ci-operator/test-images/eventshub/Dockerfile
+++ b/openshift/ci-operator/test-images/eventshub/Dockerfile
@@ -1,3 +1,4 @@
 FROM base
 ADD eventshub /usr/bin/eventshub
+USER 65532
 ENTRYPOINT ["/usr/bin/eventshub"]

--- a/openshift/ci-operator/test-images/wathola-forwarder/Dockerfile
+++ b/openshift/ci-operator/test-images/wathola-forwarder/Dockerfile
@@ -1,3 +1,4 @@
 FROM base
 ADD wathola-forwarder /usr/bin/wathola-forwarder
+USER 65532
 ENTRYPOINT ["/usr/bin/wathola-forwarder"]


### PR DESCRIPTION
As evidenced in https://github.com/openshift/knative-client/pull/1007#issuecomment-1092106565 UID sometimes could be `root uid:0`, even on OpenShift.

To make it consistent, setting UID to unknown value will force the binaries to be executed in consistent way across different configurations of OpenShift.