### PR TITLE
Fixing the Golangci-lint on Go 1.18 errors

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -8,13 +8,21 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.x
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
       - id: golangci_configuration
         uses: andstor/file-existence-action@v1
         with:
           files: .golangci.yaml
-      - name: GolangCI Lint
+
+      - name: Go Lint
         if: steps.golangci_configuration.outputs.files_exists == 'true'
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.43


### PR DESCRIPTION
Fixing the Golangci-lint on Go 1.18 errors:

```
  Running [/home/runner/golangci-lint-1.43.0-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt
  
  goroutine 1 [running]:
  github.com/go-critic/go-critic/checkers.init.9()
  	github.com/go-critic/go-critic@v0.6.1/checkers/checkers.go:58 +0x4b4
```

See: https://github.com/openshift-knative/kn-plugin-event/runs/5970278163?check_suite_focus=true