### PR TITLE
Reuse lint from Knative

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,28 +1,11 @@
-name: GolangCI-Lint
+name: Code Style
+
 on:
-  push:
-    branches: [ 'release-*' ]
   pull_request:
+    branches: [ 'main', 'release-*' ]
+
 jobs:
-  golangci:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17.x
 
-      - name: Check out code
-        uses: actions/checkout@v3
+  style:
+    uses: knative/actions/.github/workflows/style.yaml@main
 
-      - id: golangci_configuration
-        uses: andstor/file-existence-action@v1
-        with:
-          files: .golangci.yaml
-
-      - name: Go Lint
-        if: steps.golangci_configuration.outputs.files_exists == 'true'
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.43


### PR DESCRIPTION
Let's try to reuse the existing workflow to match `Go` and `golangci-ling` versions. I could only bump those if preferred, because it pulls some unnecessary checks.


/cc @cardil 