### PR TITLE
[release-1.5] Makefile and github action for building multiarch test images (#266)

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -1,0 +1,10 @@
+name: Multiarch builds
+
+on:
+  push:
+    branches: ['release-*']
+
+jobs:
+  multiarch-build:
+    uses: openshift-knative/hack/.github/workflows/multiarch-build.yaml@main
+    secrets: inherit

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,2 @@
+# Use :nonroot base image for all containers
+defaultBaseImage: registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+CGO_ENABLED=0
+GOOS=linux
+TEST_IMAGES=./vendor/knative.dev/eventing/test/test_images/wathola-forwarder ./vendor/knative.dev/reconciler-test/cmd/eventshub
+TEST_IMAGE_TAG ?= latest
+
+# Target used by github actions.
+test-images:
+	for img in $(TEST_IMAGES); do \
+		KO_DOCKER_REPO=$(DOCKER_REPO_OVERRIDE) ko build --tags=$(TEST_IMAGE_TAG) $(KO_FLAGS) -B $$img || exit $?; \
+	done
+.PHONY: test-images


### PR DESCRIPTION
* Make target for building and pushing multiarch test images

* Add .ko.yaml to set base image for builds

This is just a cherry-pick from release-1.4 branch.