### PR TITLE
:bug: Changing to working image

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,11 +1,12 @@
-ARG OCP_VERSION=4.15
+ARG OCP_VERSION=4.16
 ARG GOLANG_VERSION=1.21
+ARG RHEL_VERSION=8
 FROM registry.ci.openshift.org/ocp/${OCP_VERSION}:tools as tools
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-${GOLANG_VERSION}-openshift-${OCP_VERSION}
+FROM registry.ci.openshift.org/openshift/release:rhel-${RHEL_VERSION}-release-golang-${GOLANG_VERSION}-openshift-${OCP_VERSION}
 
 COPY --from=tools /usr/bin/oc /usr/bin/
 RUN ln -s /usr/bin/oc /usr/bin/kubectl
 
 # Reset the goflags to avoid the -mod=vendor flag
-ENV GOFLAGS=
+ENV GOFLAGS=''


### PR DESCRIPTION
## Changes

 - :bug: Changing to working image

This follows up on #383, which changed to a non-available image `registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.15` as visible in https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/50051/rehearse-50051-pull-ci-openshift-knative-kn-plugin-event-release-1.11-415-e2e/1777401086546546688#1:build-log.txt%3A149