### PR TITLE
:bug: Align to knative-extensions/kn-plugin-event#345

### DIFF
--- a/build/overrides/test-images.go
+++ b/build/overrides/test-images.go
@@ -6,10 +6,10 @@ import (
 	"path"
 
 	"github.com/magefile/mage/sh"
-	"github.com/wavesoftware/go-magetasks/config"
-	"github.com/wavesoftware/go-magetasks/pkg/artifact"
-	"github.com/wavesoftware/go-magetasks/pkg/ldflags"
-	"github.com/wavesoftware/go-magetasks/pkg/output/color"
+	"knative.dev/toolbox/magetasks/config"
+	"knative.dev/toolbox/magetasks/pkg/artifact"
+	"knative.dev/toolbox/magetasks/pkg/ldflags"
+	"knative.dev/toolbox/magetasks/pkg/output/color"
 )
 
 const prebuiltImageType = "🧩 test-content"


### PR DESCRIPTION
## Changes

 - :bug: Align to knative-extensions/kn-plugin-event#345

This, together with `release-main` branch resync, should fix the rehearsal errors I see: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/50051/rehearse-50051-pull-ci-openshift-knative-kn-plugin-event-release-next-415-e2e/1787425855018897408