### PR TITLE
:bug: Use download site to install oc

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,12 +1,14 @@
 ARG OCP_VERSION=4.16
 ARG GOLANG_VERSION=1.21
 ARG RHEL_VERSION=8
-FROM registry.ci.openshift.org/ocp/${OCP_VERSION}:tools as tools
-
 FROM registry.ci.openshift.org/openshift/release:rhel-${RHEL_VERSION}-release-golang-${GOLANG_VERSION}-openshift-${OCP_VERSION}
+ARG OCP_VERSION
 
-COPY --from=tools /usr/bin/oc /usr/bin/
-RUN ln -s /usr/bin/oc /usr/bin/kubectl
+# Install the oc and kubectl clients
+RUN curl -LO https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/candidate-${OCP_VERSION}/openshift-client-linux.tar.gz \
+    && tar -xzf openshift-client-linux.tar.gz \
+    && chmod +x oc kubectl \
+    && mv oc kubectl /usr/local/bin/
 
 # Reset the goflags to avoid the -mod=vendor flag
 ENV GOFLAGS=''


### PR DESCRIPTION
## Changes

 - :bug: Use download site to install oc

Fixes https://issues.redhat.com/browse/SRVCLI-399 (partially)

/kind bug