### PR TITLE
[release-1.11] :bug: Include e2e script from vendor dir

### DIFF
--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -8,7 +8,7 @@ export ARTIFACT_DIR="${ARTIFACT_DIR:-$(dirname "$(mktemp -d -u)")/build-${BUILD_
 export ARTIFACTS="${ARTIFACTS:-${ARTIFACT_DIR}}/kn-event/e2e-tests"
 mkdir -p "${ARTIFACTS}"
 
-source "$(go run knative.dev/hack/cmd/script e2e-tests.sh)"
+source "$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]:-$0}")")")/vendor/knative.dev/hack/e2e-tests.sh"
 
 set -Eeuo pipefail
 


### PR DESCRIPTION
# Changes

- [release-1.11] :bug: Include e2e script from vendor dir
  - issue introduced by https://github.com/openshift-knative/kn-plugin-event/pull/304 and the release-1.11 branch re-creation afterwards

/kind bug

This should fix the release-1.11 rehearsal of https://github.com/openshift/release/pull/50051 ([log](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/50051/rehearse-50051-pull-ci-openshift-knative-kn-plugin-event-release-1.11-415-e2e/1787805758574825472))