### PR TITLE
SRVCLI-401: :broom: Makefile for auto-discover of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+CI ?= false
+PROW_JOB_ID ?= 0
+PROW = $(shell [ "$(CI)" = "true" ] && [ "$(PROW_JOB_ID)" != "0" ] && echo "true" || echo "false")
+
+ifeq ($(PROW),true)
+	export HOME = /tmp
+	export TEST_IMAGES_DIR = /usr/bin
+endif
+
+build:
+	./mage build
+.PHONY: build
+
+unit:
+	./mage test
+.PHONY: unit
+
+e2e:
+	openshift/e2e-tests.sh
+.PHONY: e2e


### PR DESCRIPTION
## Changes

 - :broom: Makefile for tests auto-discover via openshift-knative/hack

Part of [SRVCLI-401](https://issues.redhat.com/browse/SRVCLI-401)

/kind enhancement