### PR TITLE
[release-1.16] :bug: Default the Wathola home to "/" on Openshift

### DIFF
--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -16,7 +16,8 @@ source "$(go run knative.dev/hack/cmd/script e2e-tests.sh)"
 
 set -Eeuo pipefail
 
-export KN_PLUGIN_EVENT_WATHOLA_HOMEDIR="${KN_PLUGIN_EVENT_WATHOLA_HOMEDIR:-}"
+# Default the Wathola home to "/" on Openshift (user ID: 65532)
+export KN_PLUGIN_EVENT_WATHOLA_HOMEDIR="${KN_PLUGIN_EVENT_WATHOLA_HOMEDIR:-/}"
 
 if [[ "${KN_PLUGIN_EVENT_INSTALL_SERVERLESS:-true}" == "true" ]]; then
   echo '=== Installing Serverless'


### PR DESCRIPTION
## Changes

 - :bug: Default the Wathola home to "/" on Openshift

/kind bug

This should fix test failures on 1.16 release, like https://github.com/openshift-knative/kn-plugin-event/pull/556#issuecomment-2457582168

The problem was introduced [here](https://github.com/knative-extensions/kn-plugin-event/pull/368/files#diff-ea2cf80663915dab63f2cbd9c4ca0b355155cb404f04377534484010099c6dffL180-R177). The Wathola homedir was always set to `""` (empty string) on Openshift, but after the above change that started to produce `.config/wathola/config.toml` (relative path), instead of `/.config/wathola/config.toml` (absolute path), and that relative path isn't passing the webhook validation.