### PR TITLE
:bug: Restore GOFLAGS to default (empty) on all Openshift related runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ PROW = $(shell [ "$(CI)" = "true" ] && [ "$(PROW_JOB_ID)" != "0" ] && echo "true
 ifeq ($(PROW),true)
 	export HOME = /tmp
 	export TEST_IMAGES_DIR = /usr/bin
+	# Reset the goflags to avoid the -mod=vendor flag
+	export GOFLAGS =
 endif
 
 build:

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -8,9 +8,6 @@ export ARTIFACT_DIR="${ARTIFACT_DIR:-$(dirname "$(mktemp -d -u)")/build-${BUILD_
 export ARTIFACTS="${ARTIFACTS:-${ARTIFACT_DIR}}/kn-event/e2e-tests"
 mkdir -p "${ARTIFACTS}"
 
-# Reset the goflags to avoid the -mod=vendor flag
-export GOFLAGS=''
-
 # shellcheck disable=SC1090
 source "$(go run knative.dev/hack/cmd/script e2e-tests.sh)"
 


### PR DESCRIPTION
## Changes

- Restore GOFLAGS to default (empty) on all Openshift related runs

## Context

- Follows up on https://github.com/openshift-knative/kn-plugin-event/pull/546
- Fixes errors like: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/58595/rehearse-58595-pull-ci-openshift-knative-kn-plugin-event-release-1.15-417-unit/1854805151718576128

/kind bug