### PR TITLE
:bug: Set GOPATH to avoid permission denied errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ PROW_JOB_ID ?= 0
 PROW = $(shell [ "$(CI)" = "true" ] && [ "$(PROW_JOB_ID)" != "0" ] && echo "true" || echo "false")
 
 ifeq ($(PROW),true)
+	# Openshift CI runs as high UID user
 	export HOME = /tmp
-	export TEST_IMAGES_DIR = /usr/bin
+	export GOPATH = /tmp/go
 	# Reset the goflags to avoid the -mod=vendor flag
 	export GOFLAGS =
 endif
@@ -16,6 +17,9 @@ build:
 unit:
 	./mage test
 .PHONY: unit
+
+test: unit
+.PHONY: test
 
 e2e:
 	openshift/e2e-tests.sh


### PR DESCRIPTION
This will fix errors like this: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-knative_kn-plugin-event/565/pull-ci-openshift-knative-kn-plugin-event-release-1.15-417-unit/1857034317968969728

/kind bug