### PR TITLE
:lady_beetle: Use main to always use latest, despite tags

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -7,5 +7,5 @@ project_dir="$(realpath "$(dirname "${BASH_SOURCE[0]:-$0}")/../..")"
 cd "$project_dir/openshift"
 
 exec go run \
-  github.com/openshift-knative/deviate/cmd/deviate@latest \
+  github.com/openshift-knative/deviate/cmd/deviate@main \
   sync --config "${project_dir}/.deviate.yaml"


### PR DESCRIPTION
/kind bug

Follow up on #713 

After a bit of waiting, the `@main` worked and fetched the latest commit (https://github.com/openshift-knative/deviate/commit/7ea9fbf39b0a7a3e338962bf4de4b59ff1a07c58):

```shell
$ go run github.com/openshift-knative/deviate/cmd/deviate@main --help
go: downloading github.com/openshift-knative/deviate v0.4.1-0.20250224093315-7ea9fbf39b0a
```