### PR TITLE
Change dir to project root

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 
 project_dir="$(realpath "$(dirname "${BASH_SOURCE[0]:-$0}")/../..")"
 
-cd "$project_dir/openshift"
+cd "$project_dir"
 
 exec go run \
   github.com/openshift-knative/deviate/cmd/deviate@main \


### PR DESCRIPTION
This should fix errors seen in knative-nightly-ci-kn-plugin-event jobs (see internal Jenkins build #1311 for example):

```
00:44:50  Error: configuration is invalid: /home/jenkins/workspace/ci/knative-nightly-ci-kn-plugin-event/knative-extensions/kn-plugin-event/openshift - not a git repository: repository does not exist
```