### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for kn-plugin-event-sender-115

### DIFF
--- a/openshift/ci-operator/images/kn-event-sender/Dockerfile
+++ b/openshift/ci-operator/images/kn-event-sender/Dockerfile
@@ -25,7 +25,8 @@ USER 65532
 
 LABEL \
       com.redhat.component="openshift-serverless-1-kn-event-sender-rhel8-container" \
-      name="openshift-serverless-1-tech-preview/kn-event-sender-rhel8" \
+      name="openshift-serverless-1/kn-plugin-event-sender-rhel8" \
+      cpe="cpe:/a:redhat:openshift_serverless:1.35::el8" \
       version=$VERSION \
       summary="Red Hat OpenShift Serverless 1 Kn Event Sender" \
       maintainer="serverless-support@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
