### PR TITLE
Downgrade to golang 1.25.0

### DIFF
--- a/build/go.mod
+++ b/build/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/kn-plugin-event/build
 
-go 1.25.5
+go 1.25.0
 
 require (
 	knative.dev/kn-plugin-event v0.0.0
@@ -192,7 +192,7 @@ require (
 	github.com/thanhpk/randstr v1.0.6 // indirect
 	github.com/therootcompany/xz v1.0.1 // indirect
 	github.com/theupdateframework/go-tuf v0.7.0 // indirect
-	github.com/theupdateframework/go-tuf/v2 v2.3.1 // indirect
+	github.com/theupdateframework/go-tuf/v2 v2.3.0 // indirect
 	github.com/transparency-dev/formats v0.0.0-20260119090622-e70c80e9488a // indirect
 	github.com/transparency-dev/merkle v0.0.2 // indirect
 	github.com/u-root/u-root v0.14.0 // indirect
@@ -242,4 +242,8 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
-replace knative.dev/kn-plugin-event => ../
+replace (
+	// Pin to v2.3.0 to avoid Go 1.25.5 requirement from v2.3.1+
+	github.com/theupdateframework/go-tuf/v2 => github.com/theupdateframework/go-tuf/v2 v2.3.0
+	knative.dev/kn-plugin-event => ../
+)

--- a/build/go.sum
+++ b/build/go.sum
@@ -627,8 +627,8 @@ github.com/therootcompany/xz v1.0.1 h1:CmOtsn1CbtmyYiusbfmhmkpAAETj0wBIH6kCYaX+x
 github.com/therootcompany/xz v1.0.1/go.mod h1:3K3UH1yCKgBneZYhuQUvJ9HPD19UEXEI0BWbMn8qNMY=
 github.com/theupdateframework/go-tuf v0.7.0 h1:CqbQFrWo1ae3/I0UCblSbczevCCbS31Qvs5LdxRWqRI=
 github.com/theupdateframework/go-tuf v0.7.0/go.mod h1:uEB7WSY+7ZIugK6R1hiBMBjQftaFzn7ZCDJcp1tCUug=
-github.com/theupdateframework/go-tuf/v2 v2.3.1 h1:fReZUTLvPdqIL8Rd9xEKPmaxig8GIXe0kS4RSEaRfaM=
-github.com/theupdateframework/go-tuf/v2 v2.3.1/go.mod h1:9S0Srkf3c13FelsOyt5OyG3ZZDq9OJDA4IILavrt72Y=
+github.com/theupdateframework/go-tuf/v2 v2.3.0 h1:gt3X8xT8qu/HT4w+n1jgv+p7koi5ad8XEkLXXZqG9AA=
+github.com/theupdateframework/go-tuf/v2 v2.3.0/go.mod h1:xW8yNvgXRncmovMLvBxKwrKpsOwJZu/8x+aB0KtFcdw=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.25.5
+go 1.25.0
 
 use (
 	.
-	build
+	./build
 )


### PR DESCRIPTION
Currently we see `go: go.work requires go >= 1.25.5 (running go 1.25.3; GOTOOLCHAIN=local)` in the Konflux pipelines. So downgrading the Go patch version temporarily